### PR TITLE
Call language change listeners in all updated activities

### DIFF
--- a/localizationActivity/src/main/java/com/akexorcist/localizationactivity/LocalizationDelegate.java
+++ b/localizationActivity/src/main/java/com/akexorcist/localizationactivity/LocalizationDelegate.java
@@ -133,8 +133,7 @@ public class LocalizationDelegate {
     private void checkLocaleChange() {
         if (!LanguageSetting.getLanguage().toLowerCase(Locale.getDefault())
                 .equals(currentLanguage.toLowerCase(Locale.getDefault()))) {
-            callDummyActivity();
-            activity.recreate();
+            notifyLanguageChanged();
         }
     }
 


### PR DESCRIPTION
Hi,

I need to know why a back stack activity is recreated.

Unless I did a mistake, it seems that `onBeforeLocaleChanged` and `onAfterLocaleChanged` are called only in the activity where `setLanguage` is called, and not in all back stack activities that are recreated due to this call.

So I propose to change 2 lines and always call `notifyLanguageChanged()` for all back stack activities if there is a language update.

It seems to work fine in my case. 

