### PR TITLE
Fix configuration locale not updated when calling `AppCompatActivity.attachBaseContext`

### DIFF
--- a/app/src/main/java/com/akexorcist/localizationapp/customactivity/CustomActivity.java
+++ b/app/src/main/java/com/akexorcist/localizationapp/customactivity/CustomActivity.java
@@ -32,7 +32,12 @@ public abstract class CustomActivity extends Activity implements OnLocaleChanged
 
     @Override
     protected void attachBaseContext(Context newBase) {
-        super.attachBaseContext(localizationDelegate.attachBaseContext(newBase));
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            applyOverrideConfiguration(localizationDelegate.updateConfigurationLocale(newBase));
+            super.attachBaseContext(newBase);
+        } else {
+            super.attachBaseContext(localizationDelegate.attachBaseContext(newBase));
+        }
     }
 
     @Override

--- a/localization/src/main/java/com/akexorcist/localizationactivity/core/LocalizationActivityDelegate.kt
+++ b/localization/src/main/java/com/akexorcist/localizationactivity/core/LocalizationActivityDelegate.kt
@@ -2,6 +2,7 @@ package com.akexorcist.localizationactivity.core
 
 import android.app.Activity
 import android.content.Context
+import android.content.res.Configuration
 import android.content.res.Resources
 import android.os.Build
 import android.os.Handler
@@ -57,6 +58,25 @@ open class LocalizationActivityDelegate(val activity: Activity) {
                 context.createConfigurationContext(config)
             }
             else -> context
+        }
+    }
+
+    fun updateConfigurationLocale(context: Context): Configuration {
+        val locale = LanguageSetting.getLanguageWithDefault(
+            context,
+            LanguageSetting.getDefaultLanguage(context)
+        )
+        val config = context.resources.configuration
+        return config.apply {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                config.setLocale(locale)
+                val localeList = LocaleList(locale)
+                LocaleList.setDefault(localeList)
+                config.setLocales(localeList)
+            }
+            else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                config.setLocale(locale)
+            }
         }
     }
 

--- a/localization/src/main/java/com/akexorcist/localizationactivity/ui/LocalizationActivity.kt
+++ b/localization/src/main/java/com/akexorcist/localizationactivity/ui/LocalizationActivity.kt
@@ -45,7 +45,12 @@ abstract class LocalizationActivity : AppCompatActivity(), OnLocaleChangedListen
     }
 
     override fun attachBaseContext(newBase: Context) {
-        super.attachBaseContext(localizationDelegate.attachBaseContext(newBase))
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            applyOverrideConfiguration(localizationDelegate.updateConfigurationLocale(newBase))
+            super.attachBaseContext(newBase)
+        } else {
+            super.attachBaseContext(localizationDelegate.attachBaseContext(newBase))
+        }
     }
 
     override fun getApplicationContext(): Context {


### PR DESCRIPTION
Fix #64 

### Possible Cause
If the project compiles with `androidx.appcompat:appcompat:1.2.0`, the configuration does not set locale properly when calling in `ActivityCompat.attachBaseContext` due to major change https://developer.android.com/jetpack/androidx/releases/appcompat#1.2.0
> Fixed support for Configuration override use cases, including custom locales and font scales. See [here](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-master-dev:appcompat/appcompat/src/androidTest/java/androidx/appcompat/app/NightModeCustomApplyOverrideConfigurationActivity.java) for an example of how to correctly implement overrides using appcompat:1.2.0.

### Possible Solution
I tried to fix this bug following the example from the references above.

### Testing
I have tested, and it's look fine so far, no breaking or crash.
- On a real device: Samsung Galaxy Note 8, Android 9.
- Compile project with `implementation 'androidx.appcompat:appcompat:1.1.0'` and `implementation 'androidx.appcompat:appcompat:1.2.0'`

PS. This PR is my first PR ever to contribute to other people's projects. Therefore, if there are anything wrong, please help me improve.