### PR TITLE
setLanguageWithoutNotification

### DIFF
--- a/localization/src/main/java/com/akexorcist/localizationactivity/core/LocalizationActivityDelegate.kt
+++ b/localization/src/main/java/com/akexorcist/localizationactivity/core/LocalizationActivityDelegate.kt
@@ -125,6 +125,32 @@ open class LocalizationActivityDelegate(val activity: Activity) {
         }
     }
 
+    fun setLanguageWithoutNotification(context: Context, newLanguage: String) {
+        val locale = Locale(newLanguage)
+        setLanguageWithoutNotification(context, locale)
+    }
+
+    fun setLanguageWithoutNotification(context: Context, newLanguage: String, newCountry: String) {
+        val locale = Locale(newLanguage, newCountry)
+        setLanguageWithoutNotification(context, locale)
+    }
+
+    /**
+     * Change application language but without recreating it
+     */
+    fun setLanguageWithoutNotification(context: Context, newLocale: Locale) {
+
+        val oldLocale = LanguageSetting.getLanguageWithDefault(
+            context,
+            LanguageSetting.getDefaultLanguage(context)
+        )
+        if (!isCurrentLanguageSetting(newLocale, oldLocale)) {
+            LanguageSetting.setLanguage(activity, newLocale)
+            // Don't notifiy current activity notifyLanguageChanged()
+        }
+
+    }
+
     // Get current language
     fun getLanguage(context: Context): Locale {
         return LanguageSetting.getLanguageWithDefault(

--- a/localization/src/main/java/com/akexorcist/localizationactivity/ui/LocalizationActivity.kt
+++ b/localization/src/main/java/com/akexorcist/localizationactivity/ui/LocalizationActivity.kt
@@ -92,6 +92,18 @@ abstract class LocalizationActivity : AppCompatActivity, OnLocaleChangedListener
         localizationDelegate.setLanguage(this, locale)
     }
 
+    fun setLanguageWithoutNotification(language: String) {
+        localizationDelegate.setLanguageWithoutNotification(this, language)
+    }
+
+    fun setLanguageWithoutNotification(language: String, country: String) {
+        localizationDelegate.setLanguageWithoutNotification(this, language, country)
+    }
+
+    fun setLanguageWithoutNotification(locale: Locale) {
+        localizationDelegate.setLanguageWithoutNotification(this, locale)
+    }
+
     fun getCurrentLanguage(): Locale {
         return localizationDelegate.getLanguage(this)
     }


### PR DESCRIPTION
Add support for changing language without activity recreate as requested on issue #70
It is useful when:
* Initial language is auto selected by GPS location, IP... 
* The screen where you choose the app language finish after language selection.