### PR TITLE
fix: activity Intent can be NULL

### DIFF
--- a/localization/src/main/java/com/akexorcist/localizationactivity/core/LocalizationActivityDelegate.kt
+++ b/localization/src/main/java/com/akexorcist/localizationactivity/core/LocalizationActivityDelegate.kt
@@ -2,6 +2,7 @@ package com.akexorcist.localizationactivity.core
 
 import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.content.res.Configuration
 import android.content.res.Resources
 import android.os.Build
@@ -137,10 +138,10 @@ open class LocalizationActivityDelegate(val activity: Activity) {
     // If yes, bundle will be remove and set boolean flag to "true".
     private fun checkBeforeLocaleChanging() {
         val isLocalizationChanged =
-            activity.intent.getBooleanExtra(KEY_ACTIVITY_LOCALE_CHANGED, false)
+            activity.intent?.getBooleanExtra(KEY_ACTIVITY_LOCALE_CHANGED, false) ?: false
         if (isLocalizationChanged) {
             this.isLocalizationChanged = true
-            activity.intent.removeExtra(KEY_ACTIVITY_LOCALE_CHANGED)
+            activity.intent?.removeExtra(KEY_ACTIVITY_LOCALE_CHANGED)
         }
     }
 
@@ -162,6 +163,9 @@ open class LocalizationActivityDelegate(val activity: Activity) {
     // Let's take it change! (Using recreate method that available on API 11 or more.
     private fun notifyLanguageChanged() {
         sendOnBeforeLocaleChangedEvent()
+        if (activity.intent == null)
+            activity.intent = Intent()
+
         activity.intent.putExtra(KEY_ACTIVITY_LOCALE_CHANGED, true)
         activity.recreate()
     }


### PR DESCRIPTION
An activity can have a null Intent, and this lead the localization library to crash