### PR TITLE
Giving context access to abstract getDefaultLanguage method.

### DIFF
--- a/localization/src/main/java/com/akexorcist/localizationactivity/ui/LocalizationApplication.kt
+++ b/localization/src/main/java/com/akexorcist/localizationactivity/ui/LocalizationApplication.kt
@@ -11,7 +11,7 @@ abstract class LocalizationApplication : Application() {
     private val localizationDelegate = LocalizationApplicationDelegate()
 
     override fun attachBaseContext(base: Context) {
-        localizationDelegate.setDefaultLanguage(base, getDefaultLanguage())
+        localizationDelegate.setDefaultLanguage(base, getDefaultLanguage(base))
         super.attachBaseContext(localizationDelegate.attachBaseContext(base))
     }
 
@@ -28,5 +28,5 @@ abstract class LocalizationApplication : Application() {
         return localizationDelegate.getResources(this)
     }
 
-    abstract fun getDefaultLanguage(): Locale
+    abstract fun getDefaultLanguage(base: Context): Locale
 }


### PR DESCRIPTION
So user of `getDefaultLanguage` can access Shared Preference and return Locale based on Persisted language.

Fixes: #106 