### PR TITLE
fix: WebView crashing on Android 5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.4.0'
     implementation 'androidx.viewpager:viewpager:1.0.0'
     implementation 'androidx.preference:preference-ktx:1.1.1'
     implementation "androidx.viewpager2:viewpager2:1.0.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,12 +29,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility project.targetJavaVersion
+        targetCompatibility project.targetJavaVersion
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = project.targetJavaVersion.toString()
     }
 
     buildFeatures {

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,8 @@ buildscript {
         targetSdkVersion = 31
         minSdkVersion = 14
 
+        targetJavaVersion = JavaVersion.VERSION_1_8
+
         versionName = '1.2.10'
         versionCode = 10210
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     project.ext {
         kotlin_version = '1.4.32'
-        compileSdkVersion = 30
-        targetSdkVersion = 30
+        compileSdkVersion = 31
+        targetSdkVersion = 31
         minSdkVersion = 14
 
         versionName = '1.2.10'

--- a/localization/build.gradle
+++ b/localization/build.gradle
@@ -29,7 +29,7 @@ task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$project.kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.4.0'
     implementation "androidx.activity:activity-ktx:1.2.2"
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'

--- a/localization/build.gradle
+++ b/localization/build.gradle
@@ -20,6 +20,14 @@ android {
             res.srcDirs = ['src/main/res']
         }
     }
+
+    compileOptions {
+        sourceCompatibility project.targetJavaVersion
+        targetCompatibility project.targetJavaVersion
+    }
+    kotlinOptions {
+        jvmTarget = project.targetJavaVersion.toString()
+    }
 }
 
 task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {

--- a/localization/src/main/java/com/akexorcist/localizationactivity/ui/LocalizationActivity.kt
+++ b/localization/src/main/java/com/akexorcist/localizationactivity/ui/LocalizationActivity.kt
@@ -2,8 +2,8 @@ package com.akexorcist.localizationactivity.ui
 
 import android.content.Context
 import android.content.res.Resources
-import android.os.Build
 import android.os.Bundle
+import androidx.annotation.CallSuper
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
 import com.akexorcist.localizationactivity.core.LocalizationActivityDelegate
@@ -30,12 +30,27 @@ abstract class LocalizationActivity : AppCompatActivity, OnLocaleChangedListener
     }
 
     override fun attachBaseContext(newBase: Context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            applyOverrideConfiguration(localizationDelegate.updateConfigurationLocale(newBase))
-            super.attachBaseContext(newBase)
-        } else {
-            super.attachBaseContext(localizationDelegate.attachBaseContext(newBase))
-        }
+        super.attachBaseContext(delegateBaseContext(newBase))
+    }
+
+    /**
+     * Get a base context for [attachBaseContext]. You can override this function to wrap this
+     * context by using ContextWrapper. For example, if your project use ViewPump from
+     * `io.github.inflationx:viewpump` module ([ViewPump](https://github.com/InflationX/ViewPump)),
+     * you can override this method to wrap this context with `ViewPumpContextWrapper`.
+     * ```Kotlin
+     * override fun delegateBaseContext(context: Context): Context {
+     *  val localizedContext: Context = super.delegateBaseContext(context)
+     *  return ViewPumpContextWrapper.wrap(localizedContext)
+     * }
+     * ```
+     * @param context a new base context from [attachBaseContext] parameter.
+     * @return a new base context. By default, it will return
+     * [LocalizationActivityDelegate.attachBaseContext]
+     */
+    @CallSuper
+    open fun delegateBaseContext(context: Context): Context {
+        return localizationDelegate.attachBaseContext(context)
     }
 
     override fun getBaseContext(): Context {


### PR DESCRIPTION
### API Changes
- Add `open fun delegateBaseContext(context: Context)` method to `LocalizationActivity`. This method should allow a custom activity to wrap localized base context with other API e.g. [ViewPump](https://github.com/InflationX/ViewPump). This should fix #116 
- By default, `delegateBaseContext(context: Context)` returns `localizationDelegate.attachBaseContext(context)`. `applyOverrideConfiguration`, IMO, is no longer needed as its solution is recommended in https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:appcompat/appcompat/src/androidTest/java/androidx/appcompat/app/NightModeCustomAttachBaseContextActivity.java

### BREAKING CHANGES
- Change `targetSdkVersion` from 30 to 31
- Change `appcompat` version to `1.4.0`

### Note
I have locally tested instrument tests on Android 4.4 (sdk 19), Android 5 (sdk 21) and Android 9 (sdk 28) devices. Please run your CI after merging this PR to `fix-web-view-crashing` branch since the CI only runs when PR to `master`.